### PR TITLE
Implementer retry-then-fail for ferdigstill og feilregistrer

### DIFF
--- a/eux-journalarkivar-integration/src/main/kotlin/no/nav/eux/journalarkivar/integration/eux/navrinasak/model/EuxSedJournalstatus.kt
+++ b/eux-journalarkivar-integration/src/main/kotlin/no/nav/eux/journalarkivar/integration/eux/navrinasak/model/EuxSedJournalstatus.kt
@@ -14,7 +14,9 @@ data class EuxSedJournalstatus(
     val opprettetTidspunkt: OffsetDateTime
 ) {
     enum class Status {
-        JOURNALFOERT, UKJENT, FEILREGISTRERT, KORRUPT
+        JOURNALFOERT, UKJENT, FEILREGISTRERT, KORRUPT,
+        FEILET_FERDIGSTILL,
+        FEILET_FEILREGISTRER
     }
 
     val put

--- a/eux-journalarkivar-integration/src/main/kotlin/no/nav/eux/journalarkivar/integration/eux/navrinasak/model/EuxSedJournalstatusPut.kt
+++ b/eux-journalarkivar-integration/src/main/kotlin/no/nav/eux/journalarkivar/integration/eux/navrinasak/model/EuxSedJournalstatusPut.kt
@@ -8,4 +8,5 @@ data class EuxSedJournalstatusPut(
     val sedId: UUID,
     val sedVersjon: Int,
     val sedJournalstatus: Status,
+    val feilmelding: String? = null,
 )

--- a/eux-journalarkivar-service/src/main/kotlin/no/nav/eux/journalarkivar/service/FeilregistrerJournalposterService.kt
+++ b/eux-journalarkivar-service/src/main/kotlin/no/nav/eux/journalarkivar/service/FeilregistrerJournalposterService.kt
@@ -5,10 +5,11 @@ import no.nav.eux.journalarkivar.integration.eux.journal.client.EuxJournalClient
 import no.nav.eux.journalarkivar.integration.eux.navrinasak.client.EuxNavRinasakClient
 import no.nav.eux.journalarkivar.integration.eux.navrinasak.model.Dokument
 import no.nav.eux.journalarkivar.integration.eux.navrinasak.model.EuxSedJournalstatus
-import no.nav.eux.journalarkivar.integration.eux.navrinasak.model.EuxSedJournalstatus.Status.FEILREGISTRERT
+import no.nav.eux.journalarkivar.integration.eux.navrinasak.model.EuxSedJournalstatus.Status.*
 import no.nav.eux.journalarkivar.integration.external.saf.client.SafClient
 import no.nav.eux.journalarkivar.integration.external.saf.model.SafJournalpost
 import no.nav.eux.journalarkivar.integration.external.saf.model.SafJournalposttype.U
+import no.nav.eux.logging.clearLocalMdc
 import no.nav.eux.logging.mdc
 import org.springframework.stereotype.Service
 import java.time.OffsetDateTime.now
@@ -24,43 +25,20 @@ class FeilregistrerJournalposterService(
 
     fun feilregistrerJournalposter() {
         euxNavRinasakClient
-            .sedJournalstatuser()
+            .sedJournalstatuser(FEILET_FEILREGISTRER)
+            .also { log.info { "${it.size} dokumenter med feilet feilregistrering, forsøker på nytt" } }
+            .forEach { it.tryFeilregistrerJournalpost() }
+        clearLocalMdc()
+        euxNavRinasakClient
+            .sedJournalstatuser(UKJENT)
             .also { log.info { "${it.size} kandidater for feilregistrering" } }
             .filter { it.opprettetTidspunkt.isBefore(now().minusDays(30)) }
             .also { log.info { "${it.size} er mer enn 30 dager gamle" } }
-            .mapNotNull { it.dokumentForFeilregistrering() }
-            .also { log.info { "${it.size} har tilknyttet journalpost" } }
-            .filter { it.journalpost.bruker == null }
-            .also { log.info { "${it.size} har ikke tilknyttet bruker" } }
-            .filter { it.journalpost.journalposttype == U }
-            .also { log.info { "${it.size} er utgående og blir forsøkt feilregistrert" } }
-            .forEach { it.feilregistrer() }
+            .forEach { it.tryFeilregistrerJournalpost() }
+        clearLocalMdc()
     }
 
-    fun DokumentForFeilregistrering.feilregistrer() {
-        mdc(
-            rinasakId = euxSedJournalstatus.rinasakId,
-            sedId = euxSedJournalstatus.sedId,
-            sedVersjon = euxSedJournalstatus.sedVersjon,
-            sedType = dokument.sedType,
-            dokumentInfoId = dokument.dokumentInfoId,
-            journalpostId = journalpost.journalpostId
-        )
-        try {
-            euxJournalClient settStatusAvbrytFor journalpost.journalpostId
-            log.info { "Journalpost feilregistrert" }
-            euxSedJournalstatus settStatusTil FEILREGISTRERT
-        } catch (e: RuntimeException) {
-            log.error(e) { "Feilregistrering feilet" }
-        }
-    }
-
-    infix fun EuxSedJournalstatus.settStatusTil(journalstatus: EuxSedJournalstatus.Status) {
-        euxNavRinasakClient.put(copy(sedJournalstatus = journalstatus).put)
-        log.info { "Journalstatus satt til $journalstatus" }
-    }
-
-    fun EuxSedJournalstatus.dokumentForFeilregistrering(): DokumentForFeilregistrering? =
+    fun EuxSedJournalstatus.tryFeilregistrerJournalpost() {
         try {
             val dokument = dokument()
             mdc(
@@ -72,10 +50,49 @@ class FeilregistrerJournalposterService(
             )
             val journalpost = journalpost(dokument.dokumentInfoId)
             mdc(journalpostId = journalpost.journalpostId)
-            DokumentForFeilregistrering(this, journalpost, dokument)
-        } catch (e: RuntimeException) {
-            null
+            if (journalpost.bruker == null && journalpost.journalposttype == U) {
+                feilregistrer(dokument, journalpost)
+            }
+        } catch (e: Exception) {
+            when (sedJournalstatus) {
+                FEILET_FEILREGISTRER -> {
+                    log.error { "Feilregistrering feilet for andre gang, gir opp: ${e.message}" }
+                    settStatusTil(KORRUPT, feilmelding = e.message)
+                }
+                else -> {
+                    log.warn { "Feilregistrering feilet, forsøker igjen neste kjøring: ${e.message}" }
+                    settStatusTil(FEILET_FEILREGISTRER, feilmelding = e.message)
+                }
+            }
         }
+    }
+
+    fun EuxSedJournalstatus.feilregistrer(
+        dokument: Dokument,
+        journalpost: SafJournalpost
+    ) {
+        mdc(
+            rinasakId = rinasakId,
+            sedId = sedId,
+            sedVersjon = sedVersjon,
+            sedType = dokument.sedType,
+            dokumentInfoId = dokument.dokumentInfoId,
+            journalpostId = journalpost.journalpostId
+        )
+        euxJournalClient settStatusAvbrytFor journalpost.journalpostId
+        log.info { "Journalpost feilregistrert" }
+        settStatusTil(FEILREGISTRERT)
+    }
+
+    fun EuxSedJournalstatus.settStatusTil(
+        journalstatus: EuxSedJournalstatus.Status,
+        feilmelding: String? = null
+    ) {
+        euxNavRinasakClient.put(
+            copy(sedJournalstatus = journalstatus).put.copy(feilmelding = feilmelding)
+        )
+        log.info { "Journalstatus satt til $journalstatus" }
+    }
 
     fun EuxSedJournalstatus.dokument() =
         try {

--- a/eux-journalarkivar-service/src/main/kotlin/no/nav/eux/journalarkivar/service/FerdigstillJournalposterService.kt
+++ b/eux-journalarkivar-service/src/main/kotlin/no/nav/eux/journalarkivar/service/FerdigstillJournalposterService.kt
@@ -39,6 +39,11 @@ class FerdigstillJournalposterService(
 
     fun ferdigstillJournalposter() {
         euxNavRinasakClient
+            .sedJournalstatuser(FEILET_FERDIGSTILL)
+            .also { log.info { "${it.size} dokumenter med feilet ferdigstill, forsøker på nytt" } }
+            .forEach { it.tryFerdigstillJournalpost() }
+        clearLocalMdc()
+        euxNavRinasakClient
             .sedJournalstatuser(UKJENT)
             .also { log.info { "${it.size} dokumenter har status ukjent" } }
             .forEach { it.tryFerdigstillJournalpost() }
@@ -58,7 +63,16 @@ class FerdigstillJournalposterService(
         } catch (e: SakUtenFerdigstilteJournalposterException) {
             log.debug { e.message }
         } catch (e: Exception) {
-            log.error(e) { "Feil ved ferdigstilling av journalpost: ${e.message}" }
+            when (sedJournalstatus) {
+                FEILET_FERDIGSTILL -> {
+                    log.error { "Ferdigstilling feilet for andre gang, gir opp: ${e.message}" }
+                    settStatusTil(KORRUPT, feilmelding = e.message)
+                }
+                else -> {
+                    log.warn { "Ferdigstilling feilet, forsøker igjen neste kjøring: ${e.message}" }
+                    settStatusTil(FEILET_FERDIGSTILL, feilmelding = e.message)
+                }
+            }
         }
 
     fun EuxSedJournalstatus.ferdigstillJournalpost() {
@@ -69,7 +83,7 @@ class FerdigstillJournalposterService(
             ?: throw RuntimeException("Fant ikke dokument i nav rinasak")
         mdc(sedType = dokument.sedType, dokumentInfoId = dokument.dokumentInfoId)
         ferdigstillJournalpost(navRinasak, dokument.dokumentInfoId)
-        this settStatusTil JOURNALFOERT
+        this.settStatusTil(JOURNALFOERT)
     }
 
     fun EuxSedJournalstatus.ferdigstillJournalpost(
@@ -88,8 +102,13 @@ class FerdigstillJournalposterService(
         }
     }
 
-    infix fun EuxSedJournalstatus.settStatusTil(journalstatus: EuxSedJournalstatus.Status) {
-        euxNavRinasakClient.put(copy(sedJournalstatus = journalstatus).put)
+    fun EuxSedJournalstatus.settStatusTil(
+        journalstatus: EuxSedJournalstatus.Status,
+        feilmelding: String? = null
+    ) {
+        euxNavRinasakClient.put(
+            copy(sedJournalstatus = journalstatus).put.copy(feilmelding = feilmelding)
+        )
         log.info { "Sed journalstatus satt til $journalstatus" }
     }
 

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/AbstractApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/AbstractApiImplTest.kt
@@ -35,7 +35,7 @@ abstract class AbstractApiImplTest {
 
     @BeforeEach
     fun initialiseRestAssuredMockMvcWebApplicationContext() {
-
+        requestBodies.clear()
     }
 
     val <T : Any> T.httpEntity: HttpEntity<T>

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerRetryApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerRetryApiImplTest.kt
@@ -1,0 +1,28 @@
+package no.nav.eux.journalarkivar.webapp
+
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpMethod
+
+class FeilregistrerRetryApiImplTest : AbstractApiImplTest() {
+
+    @Test
+    fun `feilregistrer retry - FEILET_FEILREGISTRER item fails again and becomes KORRUPT`() {
+        restTemplate
+            .exchange<Void>(
+                "/api/v1/arkivarprosess/feilregistrer/execute",
+                HttpMethod.POST,
+                httpEntity()
+            )
+        println("Følgende requests ble utført:")
+        requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
+        val putBodies = requestBodies["/api/v1/sed/journalstatuser"]
+        putBodies shouldNotBe null
+        val korruptPut = putBodies!!.firstOrNull { it.contains("KORRUPT") }
+        korruptPut shouldNotBe null
+        korruptPut!! shouldEqual "/dataset/forventet/retry-feilregistrer-korrupt.json"
+        korruptPut shouldContain "feilmelding"
+    }
+}

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillRetryApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillRetryApiImplTest.kt
@@ -1,0 +1,43 @@
+package no.nav.eux.journalarkivar.webapp
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.springframework.boot.resttestclient.exchange
+import org.springframework.http.HttpMethod
+
+class FerdigstillRetryApiImplTest : AbstractApiImplTest() {
+
+    @Test
+    fun `ferdigstill retry - FEILET_FERDIGSTILL item fails again and becomes KORRUPT`() {
+        restTemplate
+            .exchange<Void>(
+                "/api/v1/arkivarprosess/ferdigstill/execute",
+                HttpMethod.POST,
+                httpEntity()
+            )
+        println("Følgende requests ble utført:")
+        requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
+        val putBodies = requestBodies["/api/v1/sed/journalstatuser"]
+        putBodies shouldNotBe null
+        val korruptPut = putBodies!!.firstOrNull { it.contains("KORRUPT") }
+        korruptPut shouldNotBe null
+        korruptPut!! shouldEqual "/dataset/forventet/retry-ferdigstill-korrupt.json"
+        korruptPut shouldContain "feilmelding"
+    }
+
+    @Test
+    fun `ferdigstill retry - happy path items still get JOURNALFOERT`() {
+        restTemplate
+            .exchange<Void>(
+                "/api/v1/arkivarprosess/ferdigstill/execute",
+                HttpMethod.POST,
+                httpEntity()
+            )
+        val putBodies = requestBodies["/api/v1/sed/journalstatuser"]
+        putBodies shouldNotBe null
+        val journalfoertCount = putBodies!!.count { it.contains("JOURNALFOERT") }
+        (journalfoertCount > 0) shouldBe true
+    }
+}

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponses.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponses.kt
@@ -18,7 +18,7 @@ fun mockResponse(request: RecordedRequest, body: String) =
 fun mockResponsePost(request: RecordedRequest, body: String) =
     when (request.uriEndsWith) {
         "/oauth2/v2.0/token" -> tokenResponse()
-        "/api/v1/sed/journalstatuser/finn" -> postSedJournalstatuserFinnResponse()
+        "/api/v1/sed/journalstatuser/finn" -> postSedJournalstatuserFinnResponse(body)
         "/graphql" -> safResponse(body)
         "/api/v1/oppgaver" -> oppgaverResponse()
         "/api/v1/oppgaver/tildelEnhetsnr" -> tildelEnhetsnrResponse(body)
@@ -42,6 +42,7 @@ fun mockResponseGet(request: RecordedRequest) =
         "/api/v1/rinasaker/1444520" -> getEuxNavRinasakResponse(1444520)
         "/api/v1/rinasaker/1444521" -> getEuxNavRinasakResponse(1444521)
         "/api/v1/rinasaker/1444522" -> getEuxNavRinasakResponse(1444522)
+        "/api/v1/rinasaker/9999999" -> response404()
         "/v3/buc/1444520/oversikt?domene=nav" -> getRinaApiResponse()
         "/v3/buc/1444521/oversikt?domene=nav" -> getRinaApiResponse()
         "/v3/buc/1444522/oversikt?domene=nav" -> getRinaApiResponse()

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponsesCommon.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponsesCommon.kt
@@ -6,3 +6,8 @@ fun response200() =
     MockResponse().apply {
         setResponseCode(200)
     }
+
+fun response404() =
+    MockResponse().apply {
+        setResponseCode(404)
+    }

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponsesEuxNavRinasak.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/mock/MockResponsesEuxNavRinasak.kt
@@ -1,5 +1,6 @@
 package no.nav.eux.journalarkivar.webapp.mock
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import okhttp3.mockwebserver.MockResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
@@ -11,16 +12,31 @@ fun getEuxNavRinasakResponse(rinasakId: Int) =
         setBody(getNavRinasakResponseJson(rinasakId))
     }
 
-fun postSedJournalstatuserFinnResponse() =
-    MockResponse().apply {
+fun postSedJournalstatuserFinnResponse(body: String): MockResponse {
+    val status = ObjectMapper()
+        .readTree(body)
+        .findValue("sedJournalstatus")
+        ?.asText()
+    val responseBody = when (status) {
+        "FEILET_FERDIGSTILL" -> sedJournalstatuserFinnResponseBody("FEILET_FERDIGSTILL")
+        "FEILET_FEILREGISTRER" -> sedJournalstatuserFinnResponseBody("FEILET_FEILREGISTRER")
+        else -> postSedJournalstatuserFinnResponseBody
+    }
+    return MockResponse().apply {
         setResponseCode(200)
         setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
-        setBody(postSedJournalstatuserFinnResponseBody)
+        setBody(responseBody)
     }
+}
 
 fun getNavRinasakResponseJson(rinasakId: Int) =
     Any::class::class.java
         .getResource("/dataset/eux-nav-rinasak/get-response-body-$rinasakId.json")!!
+        .readText()
+
+fun sedJournalstatuserFinnResponseBody(status: String) =
+    Any::class::class.java
+        .getResource("/dataset/eux-nav-rinasak/post-sed-journalstatuser-finn-response-body-$status.json")!!
         .readText()
 
 val postSedJournalstatuserFinnResponseBody =

--- a/eux-journalarkivar-webapp/src/test/resources/dataset/eux-nav-rinasak/post-sed-journalstatuser-finn-response-body-FEILET_FEILREGISTRER.json
+++ b/eux-journalarkivar-webapp/src/test/resources/dataset/eux-nav-rinasak/post-sed-journalstatuser-finn-response-body-FEILET_FEILREGISTRER.json
@@ -1,0 +1,14 @@
+{
+  "sedJournalstatuser": [
+    {
+      "rinasakId": 9999999,
+      "sedId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee02",
+      "sedVersjon": 1,
+      "sedJournalstatus": "FEILET_FEILREGISTRER",
+      "endretBruker": "testUser",
+      "endretTidspunkt": "2023-12-07T14:27:20.33111Z",
+      "opprettetBruker": "testUser",
+      "opprettetTidspunkt": "2023-12-07T14:27:20.33111Z"
+    }
+  ]
+}

--- a/eux-journalarkivar-webapp/src/test/resources/dataset/eux-nav-rinasak/post-sed-journalstatuser-finn-response-body-FEILET_FERDIGSTILL.json
+++ b/eux-journalarkivar-webapp/src/test/resources/dataset/eux-nav-rinasak/post-sed-journalstatuser-finn-response-body-FEILET_FERDIGSTILL.json
@@ -1,0 +1,14 @@
+{
+  "sedJournalstatuser": [
+    {
+      "rinasakId": 9999999,
+      "sedId": "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeee01",
+      "sedVersjon": 1,
+      "sedJournalstatus": "FEILET_FERDIGSTILL",
+      "endretBruker": "testUser",
+      "endretTidspunkt": "2023-12-07T14:27:20.33111Z",
+      "opprettetBruker": "testUser",
+      "opprettetTidspunkt": "2023-12-07T14:27:20.33111Z"
+    }
+  ]
+}

--- a/eux-journalarkivar-webapp/src/test/resources/dataset/forventet/retry-feilregistrer-korrupt.json
+++ b/eux-journalarkivar-webapp/src/test/resources/dataset/forventet/retry-feilregistrer-korrupt.json
@@ -1,0 +1,4 @@
+{
+  "rinasakId": 9999999,
+  "sedJournalstatus": "KORRUPT"
+}

--- a/eux-journalarkivar-webapp/src/test/resources/dataset/forventet/retry-ferdigstill-korrupt.json
+++ b/eux-journalarkivar-webapp/src/test/resources/dataset/forventet/retry-ferdigstill-korrupt.json
@@ -1,0 +1,4 @@
+{
+  "rinasakId": 9999999,
+  "sedJournalstatus": "KORRUPT"
+}


### PR DESCRIPTION
Closes #11

## Endringer

Implementerer **retry-then-fail** for ferdigstill- og feilregistrerflytene. Ved første feil settes mellomstatus (`FEILET_FERDIGSTILL` / `FEILET_FEILREGISTRER`) med feilmelding. Ved andre feil markeres posten som `KORRUPT`.

### Detaljer

- **EuxSedJournalstatus.Status**: Nye verdier `FEILET_FERDIGSTILL` og `FEILET_FEILREGISTRER`
- **EuxSedJournalstatusPut**: Nytt valgfritt felt `feilmelding: String?`
- **FerdigstillJournalposterService**: Retry-batch (FEILET_FERDIGSTILL) prosesseres først for å unngå eskalering til KORRUPT i samme kjøring. Feilhåndtering i `tryFerdigstillJournalpost()` setter mellomstatus ved første feil, KORRUPT ved andre.
- **FeilregistrerJournalposterService**: Restrukturert fra `mapNotNull`-kjede til per-item `try/catch` slik at feil trigger statusoppdateringer. Samme retry-then-fail-mønster.
- **SakUtenFerdigstilteJournalposterException** er unntatt — forretningsprekondisjon, ikke permanent feil
- Ved suksess sendes `feilmelding = null` for å nullstille eventuell tidligere feilmelding

### Avhengighet
Krever at eux-nav-rinasak er oppdatert med nye statuser og feilmelding-felt før deploy.