### PR TITLE
Migrate from TestRestTemplate to RestTestClient

### DIFF
--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/AbstractApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/AbstractApiImplTest.kt
@@ -2,18 +2,15 @@ package no.nav.eux.journalarkivar.webapp
 
 import io.kotest.assertions.json.shouldEqualSpecifiedJson
 import no.nav.eux.journalarkivar.Application
-import no.nav.eux.journalarkivar.webapp.common.httpEntity
-import no.nav.eux.journalarkivar.webapp.common.voidHttpEntity
 import no.nav.eux.journalarkivar.webapp.mock.RequestBodies
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.token.support.spring.test.EnableMockOAuth2Server
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.resttestclient.TestRestTemplate
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpEntity
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.client.RestTestClient
 
 @SpringBootTest(
     classes = [Application::class],
@@ -21,14 +18,14 @@ import org.springframework.test.context.ActiveProfiles
 )
 @ActiveProfiles("test")
 @EnableMockOAuth2Server
-@AutoConfigureTestRestTemplate
+@AutoConfigureRestTestClient
 abstract class AbstractApiImplTest {
 
     @Autowired
     lateinit var mockOAuth2Server: MockOAuth2Server
 
     @Autowired
-    lateinit var restTemplate: TestRestTemplate
+    lateinit var restTestClient: RestTestClient
 
     @Autowired
     lateinit var requestBodies: RequestBodies
@@ -37,11 +34,6 @@ abstract class AbstractApiImplTest {
     fun initialiseRestAssuredMockMvcWebApplicationContext() {
         requestBodies.clear()
     }
-
-    val <T : Any> T.httpEntity: HttpEntity<T>
-        get() = httpEntity(mockOAuth2Server)
-
-    fun httpEntity() = voidHttpEntity(mockOAuth2Server)
 
     infix fun String.requestNumber(number: Int) =
         with(requestBodies[this]) {

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerJournalposterApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerJournalposterApiImplTest.kt
@@ -1,19 +1,17 @@
 package no.nav.eux.journalarkivar.webapp
 
+import no.nav.eux.journalarkivar.webapp.common.token
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.http.HttpMethod
 
 class FeilregistrerJournalposterApiImplTest : AbstractApiImplTest() {
 
     @Test
     fun `POST arkivarprosess - 204`() {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/arkivarprosess/feilregistrer/execute",
-                HttpMethod.POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/arkivarprosess/feilregistrer/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
         "/api/v1/journalposter/settStatusAvbryt" requestNumber

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerRetryApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FeilregistrerRetryApiImplTest.kt
@@ -2,20 +2,18 @@ package no.nav.eux.journalarkivar.webapp
 
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import no.nav.eux.journalarkivar.webapp.common.token
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.http.HttpMethod
 
 class FeilregistrerRetryApiImplTest : AbstractApiImplTest() {
 
     @Test
     fun `feilregistrer retry - FEILET_FEILREGISTRER item fails again and becomes KORRUPT`() {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/arkivarprosess/feilregistrer/execute",
-                HttpMethod.POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/arkivarprosess/feilregistrer/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
         val putBodies = requestBodies["/api/v1/sed/journalstatuser"]

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillJournalposterApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillJournalposterApiImplTest.kt
@@ -2,20 +2,18 @@ package no.nav.eux.journalarkivar.webapp
 
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.eux.journalarkivar.webapp.common.token
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.http.HttpMethod
 
 class FerdigstillJournalposterApiImplTest : AbstractApiImplTest() {
 
     @Test
     fun `POST arkivarprosess - 204`() {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/arkivarprosess/ferdigstill/execute",
-                HttpMethod.POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/arkivarprosess/ferdigstill/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
         "/api/v1/journalposter/453802638/ferdigstill" requestNumber 0 shouldNotBe null

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillRetryApiImplTest.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/FerdigstillRetryApiImplTest.kt
@@ -3,20 +3,18 @@ package no.nav.eux.journalarkivar.webapp
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
+import no.nav.eux.journalarkivar.webapp.common.token
 import org.junit.jupiter.api.Test
-import org.springframework.boot.resttestclient.exchange
-import org.springframework.http.HttpMethod
 
 class FerdigstillRetryApiImplTest : AbstractApiImplTest() {
 
     @Test
     fun `ferdigstill retry - FEILET_FERDIGSTILL item fails again and becomes KORRUPT`() {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/arkivarprosess/ferdigstill/execute",
-                HttpMethod.POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/arkivarprosess/ferdigstill/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
         println("Følgende requests ble utført:")
         requestBodies.forEach { println("Path: ${it.key}, body: ${it.value}") }
         val putBodies = requestBodies["/api/v1/sed/journalstatuser"]
@@ -29,12 +27,11 @@ class FerdigstillRetryApiImplTest : AbstractApiImplTest() {
 
     @Test
     fun `ferdigstill retry - happy path items still get JOURNALFOERT`() {
-        restTemplate
-            .exchange<Void>(
-                "/api/v1/arkivarprosess/ferdigstill/execute",
-                HttpMethod.POST,
-                httpEntity()
-            )
+        restTestClient
+            .post()
+            .uri("/api/v1/arkivarprosess/ferdigstill/execute")
+            .header("Authorization", "Bearer ${mockOAuth2Server.token}")
+            .exchange()
         val putBodies = requestBodies["/api/v1/sed/journalstatuser"]
         putBodies shouldNotBe null
         val journalfoertCount = putBodies!!.count { it.contains("JOURNALFOERT") }

--- a/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/common/HttpEntity.kt
+++ b/eux-journalarkivar-webapp/src/test/kotlin/no/nav/eux/journalarkivar/webapp/common/HttpEntity.kt
@@ -3,23 +3,6 @@ package no.nav.eux.journalarkivar.webapp.common
 import com.nimbusds.jose.JOSEObjectType
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
-import org.springframework.http.HttpEntity
-import org.springframework.http.HttpHeaders
-import org.springframework.http.MediaType
-
-fun <T : Any> T.httpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity(this, mockOAuth2Server.httpHeaders)
-
-fun voidHttpEntity(mockOAuth2Server: MockOAuth2Server) =
-    HttpEntity<Void>(mockOAuth2Server.httpHeaders)
-
-val MockOAuth2Server.httpHeaders: HttpHeaders
-    get() {
-        val headers = HttpHeaders()
-        headers.contentType = MediaType.APPLICATION_JSON
-        headers.set("Authorization", "Bearer ${this.token}")
-        return headers
-    }
 
 val MockOAuth2Server.token: String
     get() = this


### PR DESCRIPTION
Replace TestRestTemplate with Spring Framework 7 RestTestClient for test HTTP calls.