### PR TITLE
chore(deps): bump parent-pom to 2.0.15, tomcat to 11.0.22, add depend…

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 6
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 4
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    reviewers:
+      - "navikt/eessibasis"
+    labels:
+      - "dependencies"
+      - "automerge"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/distroless/java25
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-25
 COPY eux-journalarkivar-webapp/target/eux-journalarkivar.jar /app.jar
-ENTRYPOINT ["java", "-jar", "/app.jar"]
+ENTRYPOINT ["java", "-XX:+UseContainerSupport", "-XX:MaxRAMPercentage=75.0", "-jar", "/app.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -20,13 +20,14 @@
     <parent>
         <groupId>no.nav.eux</groupId>
         <artifactId>parent-pom</artifactId>
-        <version>2.0.10</version>
+        <version>2.0.15</version>
     </parent>
 
     <properties>
         <maven.compiler.source>25</maven.compiler.source>
         <maven.compiler.target>25</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <tomcat.version>11.0.22</tomcat.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
…abot config

- Bump parent-pom from 2.0.10 to 2.0.15
- Add tomcat.version 11.0.22 property
- Switch base image to Chainguard JRE openjdk-25
- Add JVM flags UseContainerSupport and MaxRAMPercentage=75.0
- Add .github/dependabot.yml with maven daily schedule